### PR TITLE
fix: missing resources and missing install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ uses [roughnotation](https://roughnotation.com/) to create a sketchy looking htm
 
 ## Installation
 
-The template can be installed using the following command
+The template can be installed using the following command:
+
+```bash
+quarto add schochastics/quarto-sketchy-html
+```
+
+Alternatively, you can install and use a template document directly using the following command:
 
 ```bash
 quarto use template schochastics/quarto-sketchy-html

--- a/_extensions/sketchy/_extension.yml
+++ b/_extensions/sketchy/_extension.yml
@@ -1,6 +1,7 @@
 title: Sketchy HTML documents 
 author: David Schoch
 version: 1.1.0
+quarto-required: ">=1.2"
 contributes:
   formats:
     html:

--- a/_extensions/sketchy/theme.css
+++ b/_extensions/sketchy/theme.css
@@ -1,0 +1,1 @@
+/* css styles */


### PR DESCRIPTION
This PR adds the missing Quarto command to install without using the template, adds missing `theme.css` leading to a warning, and add Quarto requirements to 1.2.

PS: you might want to also tag/release your repository to allow users to target specific version of this extension when installing it.